### PR TITLE
Added starter pipeline.

### DIFF
--- a/src/evaluate_llama.py
+++ b/src/evaluate_llama.py
@@ -1,0 +1,184 @@
+import os
+import re
+import json
+import torch
+import argparse
+import pandas as pd
+from tqdm import tqdm
+from utils import seed_all
+from torch.utils.data import DataLoader
+from torch.utils.data.dataset import Dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+seed_all(42)
+
+
+def parallel_collate_fn(batch):
+    # Just concates to form a big tensor
+    input_ids = torch.cat([item[0] for item in batch], dim=0)
+    attention_mask = torch.cat([item[1] for item in batch], dim=0)
+    labels = [item[2] for item in batch]
+    return input_ids, attention_mask, labels
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--model_name", type=str, required=True)
+    parser.add_argument("--dataset_name", type=str, required=True)
+    parser.add_argument("--data_type", choices=["qa", "math"], required=True)
+    parser.add_argument("--split_name", type=str, required=True)
+    parser.add_argument("--load_in_8_bit", action="store_true", default=False)
+    parser.add_argument("--max_len", type=int, default=1024)
+    parser.add_argument("--batch_size", type=int, default=8)
+
+    args = parser.parse_args()
+    return args
+
+
+class CoTdataset(Dataset):
+
+    def __init__(self, data_path, tokenizer: AutoTokenizer, max_len=1024):
+        self.data = json.load(open(data_path, "r"))
+        self.tokenizer = tokenizer
+        self.max_len = max_len
+
+        self.preprocess()
+
+    def preprocess(self):
+
+        for i in tqdm(range(len(self.data)), desc="Tokenizing..."):
+            instance = self.data[i]["input"]
+            tokenized = self.tokenizer(instance,
+                                       return_tensors="pt",
+                                       padding="max_length",
+                                       max_length=self.max_len,
+                                       truncation=True)
+            self.data[i]["input_ids"] = tokenized["input_ids"]
+            self.data[i]["attention_mask"] = tokenized["attention_mask"]
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]["input_ids"], self.data[idx][
+            "attention_mask"], self.data[idx]["label"]
+
+
+def main():
+
+    args = parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(device)
+
+    model_args = {
+        "pretrained_model_name_or_path":
+        f"saved/base_models/{args.model_name}",
+        "low_cpu_mem_usage": True,
+        "load_in_8bit": args.load_in_8_bit,
+    }
+    if not args.load_in_8_bit:
+        model_args["torch_dtype"] = torch.bfloat16
+
+    model = AutoModelForCausalLM.from_pretrained(**model_args)
+    if not args.load_in_8_bit:
+        model.to(device)
+    tokenizer = AutoTokenizer.from_pretrained(
+        f"saved/base_models/{args.model_name}", padding_side="left")
+
+    tokenizer.add_special_tokens({"pad_token": "<pad>"})
+    model.resize_token_embeddings(len(tokenizer))
+    model.config.pad_token_id = tokenizer.pad_token_id
+
+    gen_kwargs = json.load(open("data/baseline_gen_config.json"))
+    # Needed because math explanations are long
+    if args.data_type == "math":
+        gen_kwargs["max_new_tokens"] = 200
+    gen_kwargs["pad_token_id"] = tokenizer.pad_token_id
+    gen_kwargs["eos_token_id"] = [
+        tokenizer.eos_token_id,
+        tokenizer.convert_tokens_to_ids("<|eot_id|>")
+    ]
+
+    dataset = CoTdataset(
+        f"data/{args.dataset_name}/{args.split_name}_prompts.json", tokenizer,
+        args.max_len)
+
+    dataloader = DataLoader(dataset,
+                            batch_size=args.batch_size,
+                            shuffle=False,
+                            collate_fn=parallel_collate_fn)
+
+    new_df = {"decoded": [], "answer": [], "label": []}
+    if args.data_type == "qa":
+        pattern = r"\((.)\)"
+    elif args.dataset_name == "aqua":
+        # Aqua has a different format, and the LLM sometimes doesn't generate "(" or ")"
+        pattern = r"The answer is \(?(.)\)?"
+    elif args.data_type == "math":
+        # This is for the math dataset
+        pattern = r"The answer is (-?\d+)."
+
+    err_inds = []
+
+    for (ids, attn_mask, labels) in tqdm(dataloader):
+
+        generated = model.generate(input_ids=ids.to(device),
+                                   attention_mask=attn_mask.to(device),
+                                   **gen_kwargs)
+        decoded = tokenizer.batch_decode(generated[:, args.max_len:],
+                                         skip_special_tokens=True)
+
+        answers = []
+        for i in range(len(decoded)):
+            # No need to split for math because the answers themselves cointain "\n", for aqua the case is different
+            if args.data_type == "qa" or args.dataset_name == "aqua":
+                answers.append(decoded[i].split("\n")[0])
+            else:
+                answers.append(decoded[i])
+            match = re.search(pattern, answers[i])
+            if match:
+                answers[i] = match.group(1).lower()
+                if args.dataset_name == "aqua":
+                    # Aqua's pattern also matches "(" and ")" in the answer, need to remove them
+                    answers[i] = answers[i].replace("(", "")
+                    answers[i] = answers[i].replace(")", "")
+                try:
+                    # Convert to ints if the data type is math
+                    if args.data_type == "math" and not args.dataset_name == "aqua":
+                        answers[i] = int(answers[i].replace(",", ""))
+                except:
+                    err_inds.append(i)
+                    answers[i] = -1
+
+        new_df["decoded"].extend(decoded)
+        new_df["answer"].extend(answers)
+        if args.data_type == "qa":
+            new_df["label"].extend(labels)
+        elif args.dataset_name == "aqua":
+            new_df["label"].extend([x.lower() for x in labels])
+        else:
+            new_df["label"].extend([int(x) for x in labels])
+
+    new_df = pd.DataFrame(new_df)
+    if not os.path.exists(f"out/{args.dataset_name}"):
+        os.makedirs(f"out/{args.dataset_name}")
+    if not os.path.exists(f"out/{args.dataset_name}/{args.model_name}"):
+        os.makedirs(f"out/{args.dataset_name}/{args.model_name}")
+    new_df.to_csv(
+        f"out/{args.dataset_name}/{args.model_name}/8_bit_{args.load_in_8_bit}_{args.split_name}_predictions.csv",
+        index=False)
+    acc = (new_df["answer"] == new_df["label"]).mean()
+    print(f"Accuracy: {acc}")
+    acc = {"Accuracy": acc, "Error Indices": err_inds}
+    json.dump(
+        acc,
+        open(
+            f"out/{args.dataset_name}/{args.model_name}/8_bit_{args.load_in_8_bit}_{args.split_name}_metrics.json",
+            "w"))
+
+
+if __name__ == '__main__':
+
+    main()

--- a/src/process_math_datasets.py
+++ b/src/process_math_datasets.py
@@ -1,0 +1,106 @@
+import argparse
+from datasets import load_dataset
+
+from tqdm import tqdm
+from utils import *
+import re
+
+
+def process_gsm8k(row):
+    pattern = r"#### (-?\d+)"
+    match = re.search(pattern, row["answer"])
+    int_answer = None
+    if match:
+        int_answer = match.group(1)
+    else:
+        print("Exception")
+    return {
+        "question": row["question"],
+        "label": int_answer,
+        "label_text": row["answer"]
+    }
+
+
+def process_svamp(row):
+    return {
+        'id': row['ID'],
+        'question': row['Body'] + row['Question'],
+        'label': row['Answer'],
+        'label_text': row["Type"] + " ," + row["Equation"],
+    }
+
+
+def process_aqua(row):
+    full_question = row['question'] + ' ' + ' '.join(row['options'])
+    return {
+        'question': full_question,
+        'label': row['correct'],
+        'label_text': row['rationale'],
+    }
+
+
+def main(args):
+    if args.dataset == 'gsm8k':
+        raw_dataset = load_dataset('gsm8k', 'main')
+        demonstration_file = 'prompts/math/cot_prompt.txt'
+        splits = ['train', 'test']
+        process_fn = process_gsm8k
+
+    elif args.dataset == 'svamp':
+        raw_dataset = load_dataset('ChilleD/SVAMP')
+        demonstration_file = 'prompts/math/cot_prompt.txt'
+        splits = ['train', 'test']
+        process_fn = process_svamp
+
+    elif args.dataset == 'aqua':
+        raw_dataset = load_dataset('aqua_rat')
+        demonstration_file = 'prompts/aqua/cot_prompt.txt'
+        splits = ['train', 'validation', 'test']
+        process_fn = process_aqua
+
+    # read the demonstration
+    with open(demonstration_file) as f:
+        demonstration = f.read()
+
+    if args.combine:
+        combined = []
+    # process the dataset by prepending the demonstration to create prompt
+    for split in splits:
+        prompt_data = []
+        for row in tqdm(raw_dataset[split],
+                        desc=f'Processing {args.dataset} {split}...'):
+            item = process_fn(row)
+            prompt = demonstration + f"\nQ: {item['question']} \nA: "
+            prompt_data.append({
+                'input': prompt,
+                'dataset': args.dataset,
+                'label': item['label'],
+                'label_text': item['label_text'],
+            })
+            if args.combine:
+                combined.append({
+                    'input': prompt,
+                    'dataset': args.dataset,
+                    'label': item['label'],
+                    'label_text': item['label_text'],
+                })
+        write_json(
+            f'./data/{args.dataset}/{split}_prompts.json',
+            prompt_data,
+            mode='w',
+            make_dir=True)
+    if args.combine:
+        write_json(
+            f'./data/{args.dataset}/combined_prompts.json',
+            combined,
+            mode='w',
+            make_dir=True)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process MATH datasets')
+    parser.add_argument('--dataset', choices=['gsm8k', 'svamp', 'aqua'])
+    parser.add_argument('--combine', action='store_true', default=False)
+    args = parser.parse_args()
+
+    main(args)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,94 @@
+import csv, json
+from pathlib import Path
+
+
+def seed_all(seed):
+    try:
+        import torch
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+    except ImportError:
+        pass
+
+    try:
+        import random
+        random.seed(seed)
+    except ImportError:
+        pass
+
+    try:
+        import numpy as np
+        np.random.seed(seed)
+    except ImportError:
+        pass
+
+
+def read_csv(fname):
+    with open(fname) as f:
+        reader = csv.reader(f)
+        all_data = []
+        for row in reader:
+            all_data.append(row)
+
+    return all_data
+
+
+def write_csv(fname, data, header=None, mode='w', make_dir=False):
+    if make_dir:
+        fpath = fname.rsplit('/', 1)[0]
+        Path(fpath).mkdir(parents=True, exist_ok=True)
+
+    with open(fname, mode) as f:
+        writer = csv.writer(f)
+        if header:
+            writer.writerow(header)
+        writer.writerows(data)
+
+
+def read_csv_as_json(fname, header=None):
+    with open(fname) as f:
+        if header:
+            reader = csv.DictReader(f, header)
+        else:
+            tmp_reader = csv.reader(f)
+            reader = csv.DictReader(f, next(tmp_reader, None))
+        all_data = []
+        for row in reader:
+            all_data.append(row)
+
+    return all_data
+
+
+def read_csv_as_dictionary(fname, dict_key, header=None):
+    with open(fname) as f:
+        if header:
+            reader = csv.DictReader(f, header)
+        else:
+            tmp_reader = csv.reader(f)
+            reader = csv.DictReader(f, next(tmp_reader, None))
+        all_data = []
+        for row in reader:
+            all_data.append(row)
+
+    dict_data = dict()
+    for row in all_data:
+        if type(dict_key) == str:
+            dict_data[row[dict_key]] = row
+        elif callable(dict_key):
+            dict_data[dict_key(row)] = row
+
+    return dict_data
+
+
+def read_json(fname):
+    with open(fname) as f:
+        return json.load(f)
+
+
+def write_json(fname, data, mode='w', make_dir=False):
+    if make_dir:
+        fpath = fname.rsplit('/', 1)[0]
+        Path(fpath).mkdir(parents=True, exist_ok=True)
+
+    with open(fname, mode) as f:
+        json.dump(data, f, indent=4)


### PR DESCRIPTION
- `utils.py` - this is lite, like easy to read helper functions like read helper functions, has `seed_all` which seeds random, numpy and torch; others maybe useful ones are `write_json` and `read_json`.
- `process_math_datasets.py` has all the logic for a general preprocessing as well. You guys have to adapt this to [BoolQ](https://huggingface.co/datasets/google/boolq) and [MAWPS](https://huggingface.co/datasets/MU-NLPC/Calc-mawps) which from what I can see is a Math dataset (yay!).
- `evaluate_llama.py` does it in a CoT manner, so not very useful here? But can adapt easily, though I did use it as is for the Math Datasets so should be no problem for MAWPS.